### PR TITLE
refactor: remove Google social provider configuration from auth.js

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -74,13 +74,6 @@ export const auth = betterAuth({
     autoSignInAfterVerification: true,
     sendVerificationOnSignUp: true,
   },
-  socialProviders: {
-    google: {
-      prompt: 'select_account',
-      clientId: process.env.GOOGLE_CLIENT_ID,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-    },
-  },
 
   plugins: [
     inferAdditionalFields({


### PR DESCRIPTION
- Eliminate the Google social provider settings from the authentication configuration to streamline the codebase and reduce potential security risks associated with unused credentials.
- This change focuses on maintaining a cleaner and more maintainable authentication setup.