### PR TITLE
chore: update allowed origins in index.js to reflect new frontend URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ app.set('trust proxy', 1);
 const allowedOrigins = [
   'http://localhost:3000',
   'http://localhost:8090',
-  'https://ewo.vercel.app',
+  'https://ewo-admin.vercel.app',
   process.env.FRONTEND_URL,
 ].filter(Boolean);
 


### PR DESCRIPTION
- Changed the allowed origin from 'https://ewo.vercel.app' to 'https://ewo-admin.vercel.app' in index.js to accommodate the updated frontend deployment.
- This change aims to ensure proper CORS handling and maintain security by allowing only the intended frontend application to access the backend resources.